### PR TITLE
add confirmation dialog

### DIFF
--- a/DueMate/Calendar/CalendarView.swift
+++ b/DueMate/Calendar/CalendarView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CalendarView: View {
     @Binding var history: [String]
     @StateObject private var viewModel = CalendarViewModel()
-    @State private var selectedDate: Date?
+    @Binding var selectedDate: Date?
     
     var body: some View {
         VStack {
@@ -55,6 +55,7 @@ struct CalendarView: View {
                     CalendarCellView(theCell: cell)
                         .onTapGesture {
                             guard cell.isSelectable else { return }
+                            selectedDate = cell.date
                             viewModel.selectedDate = cell.date
                             viewModel.generateCalendar()
                         }
@@ -78,6 +79,7 @@ struct CalendarView: View {
 
 
 #Preview {
+    @Previewable @State var selectedDate: Date? = nil
     CalendarView(history: .constant(["2025-05-01",
-                                     "2025-05-10"]))
+                                     "2025-05-10"]), selectedDate: $selectedDate)
 }

--- a/DueMate/View/Chores/ChoreMainView.swift
+++ b/DueMate/View/Chores/ChoreMainView.swift
@@ -75,7 +75,6 @@ struct ChoreMainView: View {
                     type: .mainViewCompletion,
                     onConfirm: {
                         viewModel.completeChore(item)
-                        
                     }
                 )
             }

--- a/DueMate/View/Chores/ChoreMainView.swift
+++ b/DueMate/View/Chores/ChoreMainView.swift
@@ -9,59 +9,75 @@ import SwiftUI
 
 struct ChoreMainView: View {
     @StateObject private var viewModel = ChoreMainViewModel()
+    @State private var showDialog = false
+    @State private var selectedItem: ChoreItem? = nil
     
     var body: some View {
-        NavigationStack{
-            HStack{
-                Text("HOUSEHOLD\nLIST")
-                    .font(.system(size: 40, weight: .bold))
-                Spacer()
-                NavigationLink {
-                    ChoreCreateView(onComplete:{
-                        print("MainView: complete!!")
-                        viewModel.fetchChores()
-                    })
-                }label: {
-                    Image(systemName: "plus")
-                        .font(.system(size: 40))
-                        .foregroundStyle(.black)
+        ZStack {
+            NavigationStack{
+                HStack{
+                    Text("HOUSEHOLD\nLIST")
+                        .font(.system(size: 40, weight: .bold))
+                    Spacer()
+                    NavigationLink {
+                        ChoreCreateView(onComplete:{
+                            print("MainView: complete!!")
+                            viewModel.fetchChores()
+                        })
+                    }label: {
+                        Image(systemName: "plus")
+                            .font(.system(size: 40))
+                            .foregroundStyle(.black)
+                    }
+                    .padding()
+                }
+                .padding()
+                .padding(.top, 30)
+                
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(viewModel.items) { item in
+                            NavigationLink {
+                                ChoreDetailView(item: item)
+                                    .environmentObject(viewModel)
+                            }label: {
+                                ChoreItemView(item: item, color: viewModel.getListColor(due: item.nextDue), onCheckToggled: {
+                                    selectedItem = item
+                                    showDialog = true
+                                    
+                                } )
+                            }
+                            .buttonStyle(.plain)
+                            
+                        }
+                    }
+                    
+                    
+                    
                 }
                 .padding()
             }
-            .padding()
-            .padding(.top, 30)
+            .onAppear {
+                print("main onAppear")
+                viewModel.fetchChores()
+            }
+            .onChange(of: viewModel.shouldRefresh) {
+                if viewModel.shouldRefresh {
+                    print("main refresh")
+                    viewModel.fetchChores()
+                    viewModel.shouldRefresh = false
+                }
+            }
             
-            ScrollView {
-                LazyVStack(spacing: 16) {
-                    ForEach(viewModel.items) { item in
-                        NavigationLink {
-                            ChoreDetailView(item: item)
-                                .environmentObject(viewModel)
-                        }label: {
-                            ChoreItemView(item: item, color: viewModel.getListColor(due: item.nextDue), onCheckToggled: {
-                                //vm server networking
-                                print("check Toggeld!")
-                            } )
-                        }
-                        .buttonStyle(.plain)
+            if showDialog, let item = selectedItem {
+                ConfirmationDialog(
+                    isPresented: $showDialog,
+                    type: .mainViewCompletion,
+                    onConfirm: {
+                        viewModel.completeChore(item)
                         
                     }
-                }
-                
-                
-                
-            }
-            .padding()
-        }
-        .onAppear {
-            print("main onAppear")
-            viewModel.fetchChores()
-        }
-        .onChange(of: viewModel.shouldRefresh) {
-            if viewModel.shouldRefresh {
-                print("main refresh")
-                viewModel.fetchChores()
-                viewModel.shouldRefresh = false
+                )
             }
         }
         

--- a/DueMate/View/Common/ConfirmationDialog.swift
+++ b/DueMate/View/Common/ConfirmationDialog.swift
@@ -1,0 +1,78 @@
+//
+//  ConfirmationDialog.swift
+//  DueMate
+//
+//  Created by Kacey Kim on 5/17/25.
+//
+
+import SwiftUI
+
+
+enum DialogType {
+    case mainViewCompletion
+    case historyCompletion
+    case historyCancelation
+    
+    var message: String {
+        switch self {
+        case .mainViewCompletion:
+            return "오늘 할 일을 완료하셨나요?"
+        case .historyCompletion:
+            return "이 날짜에 완료 처리할까요?"
+        case .historyCancelation:
+            return "이 날짜의 기록을 지울까요?"
+        }
+    }
+    
+    var confirmText: String {
+        switch self {
+        case .historyCancelation:
+            return "삭제"
+        default:
+            return "확인"
+        }
+    }
+    
+    var cancelText: String {
+        return "취소"
+    }
+}
+
+
+struct ConfirmationDialog: View {
+    @Binding var isPresented: Bool
+    let type: DialogType
+    let onConfirm: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(type.message)
+                .font(.headline)
+            HStack {
+                Button(action: {
+                    isPresented = false
+                }) {
+                    Text(type.cancelText)
+                        .frame(maxWidth: .infinity)
+                }
+                Button(action: {
+                    onConfirm()
+                    isPresented = false
+                }){
+                    Text(type.confirmText)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            
+        }
+        .padding()
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(radius: 10)
+        .frame(maxWidth: 300)
+    }
+}
+
+#Preview {
+    ConfirmationDialog(isPresented: .constant(true), type: .historyCompletion, onConfirm: {})
+}

--- a/DueMate/ViewModel/ChoreMainViewModel.swift
+++ b/DueMate/ViewModel/ChoreMainViewModel.swift
@@ -33,6 +33,10 @@ class ChoreMainViewModel: ObservableObject {
             }
     }
     
+    func completeChore(_ chore: ChoreItem) {
+        print("\(chore.title) 췍!!!!")
+    }
+    
     func sortByDueDate() {
         items.sort { (item1, item2) -> Bool in
             return item1.nextDue < item2.nextDue


### PR DESCRIPTION
## 🔍 Overview
<!-- Explain the purpose of this PR in a way that even developers from different domains can understand. -->

Added a reusable confirmation dialog component that can be used across multiple features in the future

## ✨ Changes
<!-- List the main changes made in this PR -->

- three types of confirmation dialog
  - When a user taps the checkmark on the main view to complete a chore → Show a dialog to add today's date to the history
  - When a user taps a date not in the history on the detail view's calendar → Show a dialog to add that specific date to the history
  - When a user taps a date already in the history on the detail view's calendar → Show a dialog to remove that date from the history

## 📸 Screenshots
<!-- If this PR affects the UI, attach screenshots or screen recordings -->

| MainView | Not in history | In history |
| --- | --- | -- |
| <img src="https://github.com/user-attachments/assets/860ced7b-395e-4632-9928-d250fb93e36a" width="220"/> | <img src="https://github.com/user-attachments/assets/a1808351-6636-4068-83e0-8469161a4205" width="220"/> | <img src="https://github.com/user-attachments/assets/232a6bd0-21ac-4f13-99c1-1c565434d08c" width="220"/> |

## 🔗 Related Task
<!-- Link to relevant Jira ticket(s) -->

- JIRA: [HOME-57](https://home-protectors.atlassian.net/browse/HOME-57)
