### PR TITLE
Implement stock create view

### DIFF
--- a/DueMate/Extension/String.swift
+++ b/DueMate/Extension/String.swift
@@ -22,7 +22,7 @@ extension String {
 }
 
 extension Int {
-    func getReminderOption() -> alertOptions {
+    func getReminderOption() -> ReminderOptions {
         switch self {
         case 0: return .theDay
         case 1: return .oneDayBefore

--- a/DueMate/View/Chores/ChoreCreateView.swift
+++ b/DueMate/View/Chores/ChoreCreateView.swift
@@ -15,12 +15,14 @@ struct ChoreCreateView: View {
     @StateObject private var viewModel = ChoreCreateViewModel()
     @State private var showPicker = false
     
+    private let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.minimum = 1
+        formatter.maximum = 365
+        return formatter
+    }()
     
-    // Form Validation
-    var isFormValid: Bool {
-        !viewModel.title.trimmingCharacters(in: .whitespaces).isEmpty &&
-        !viewModel.cycle.trimmingCharacters(in: .whitespaces).isEmpty
-    }
     
     
     var body: some View {
@@ -49,7 +51,10 @@ struct ChoreCreateView: View {
                     .foregroundColor(.gray)
                 
                 HStack {
-                    TextField("1-365", text: $viewModel.cycle)
+                    TextField("1-365", value: Binding(
+                        get: { Int(viewModel.cycle) ?? 0 },
+                        set: { viewModel.cycle = String($0) }
+                    ), formatter: numberFormatter)
                         .keyboardType(.numberPad)
                         .padding()
                         .background(Color(.systemGray6))
@@ -109,11 +114,11 @@ struct ChoreCreateView: View {
                     .font(.headline)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(isFormValid ? Color.black : Color.gray.opacity(0.4))
-                    .foregroundColor(isFormValid ? .white : .gray)
+                    .background(viewModel.isFormValid ? Color.black : Color.gray.opacity(0.4))
+                    .foregroundColor(viewModel.isFormValid ? .white : .gray)
                     .cornerRadius(16)
             }
-            .disabled(!isFormValid)
+            .disabled(!viewModel.isFormValid)
             .padding(.top, 12)
             .onChange(of:viewModel.isChoreCreated){
                 if viewModel.isChoreCreated {

--- a/DueMate/View/Chores/ChoreCreateView.swift
+++ b/DueMate/View/Chores/ChoreCreateView.swift
@@ -97,7 +97,7 @@ struct ChoreCreateView: View {
                     .cornerRadius(12)
                 }
                 .sheet(isPresented: $showPicker) {
-                    AlertSheet(alert: $viewModel.selectedAlert)
+                    ReminderPickerView(alert: $viewModel.selectedAlert)
                 }
             }
             

--- a/DueMate/View/Chores/ChoreCreateView.swift
+++ b/DueMate/View/Chores/ChoreCreateView.swift
@@ -125,6 +125,7 @@ struct ChoreCreateView: View {
             
             Spacer()
         }
+        .toolbar(.hidden, for: .tabBar)
         .padding(24)
         .background(Color(.systemBackground))
     }

--- a/DueMate/View/Chores/ChoreDetailView.swift
+++ b/DueMate/View/Chores/ChoreDetailView.swift
@@ -80,7 +80,7 @@ struct ChoreDetailView: View {
                             .cornerRadius(12)
                         }
                         .sheet(isPresented: $showReminderPicker) {
-                            AlertSheet(alert: $viewModel.reminderOption)
+                            ReminderPickerView(alert: $viewModel.reminderOption)
                         }
                     }
                     
@@ -177,7 +177,7 @@ struct ChoreDetailView: View {
             Text("저장하지 않은 변경 사항이 사라집니다.")
         }
         .onAppear{
-            var reminder: alertOptions
+            var reminder: ReminderOptions
             if !item.reminderEnabled {
                 reminder = .none
             }else{

--- a/DueMate/View/Chores/ChoreDetailView.swift
+++ b/DueMate/View/Chores/ChoreDetailView.swift
@@ -154,6 +154,7 @@ struct ChoreDetailView: View {
         }
         .padding()
         .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .tabBar)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: {

--- a/DueMate/View/Chores/ChoreDetailView.swift
+++ b/DueMate/View/Chores/ChoreDetailView.swift
@@ -15,7 +15,7 @@ struct ChoreDetailView: View {
     
     @State private var selectedDate : Date? = nil
     @State private var showDialog = false
-    @State private var showPicker = false
+    @State private var showReminderPicker = false
     @State private var showDeleteAlert = false
     @State private var showCancelAlert = false
     
@@ -66,7 +66,7 @@ struct ChoreDetailView: View {
                             .foregroundColor(.gray)
                         
                         Button(action: {
-                            showPicker = true
+                            showReminderPicker = true
                         }) {
                             HStack {
                                 Text(viewModel.reminderOption.rawValue)
@@ -79,7 +79,7 @@ struct ChoreDetailView: View {
                             .background(Color(.systemGray6))
                             .cornerRadius(12)
                         }
-                        .sheet(isPresented: $showPicker) {
+                        .sheet(isPresented: $showReminderPicker) {
                             AlertSheet(alert: $viewModel.reminderOption)
                         }
                     }

--- a/DueMate/View/Common/MainTabView.swift
+++ b/DueMate/View/Common/MainTabView.swift
@@ -10,10 +10,20 @@ import SwiftUI
 struct MainTabView: View {
     var body: some View {
         TabView {
-            ChoreMainView()
-                .tabItem{
-                    Label("Chore", systemImage: "house")
-                }
+            NavigationStack {
+                ChoreMainView()
+            }
+            .tabItem{
+                Label("", systemImage: "house")
+                
+            }
+            
+            NavigationStack {
+                StockCreateView()
+            }
+            .tabItem {
+                Label("", systemImage: "cart.fill")
+            }
         }
         
     }

--- a/DueMate/View/Common/ReminderPickerView.swift
+++ b/DueMate/View/Common/ReminderPickerView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum alertOptions: String, CaseIterable{
+enum ReminderOptions: String, CaseIterable{
     case none = "없음"
     case theDay = "당일 (9am)"
     case oneDayBefore = "하루 전(9am)"
@@ -25,9 +25,9 @@ enum alertOptions: String, CaseIterable{
 
 
 
-struct AlertSheet: View {
+struct ReminderPickerView: View {
     @Environment(\.dismiss) private var dismiss
-    @Binding var alert:alertOptions
+    @Binding var alert:ReminderOptions
     
     var body: some View {
         VStack{
@@ -42,7 +42,7 @@ struct AlertSheet: View {
                 }
             }
             Picker("Select", selection: $alert){
-                ForEach(alertOptions.allCases, id:\.self){
+                ForEach(ReminderOptions.allCases, id:\.self){
                     Text($0.rawValue)
                 }
             }
@@ -55,5 +55,5 @@ struct AlertSheet: View {
 }
 
 #Preview {
-    AlertSheet(alert: .constant(.none))
+    ReminderPickerView(alert: .constant(.none))
 }

--- a/DueMate/View/Stocks/StockCreateView.swift
+++ b/DueMate/View/Stocks/StockCreateView.swift
@@ -17,6 +17,13 @@ struct StockCreateView: View {
     @State private var showReminderPicker = false
     @State private var showExpectedText = false
     
+    private let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.minimum = 1
+        formatter.maximum = 999999
+        return formatter
+    }()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
@@ -42,7 +49,7 @@ struct StockCreateView: View {
                     .font(.subheadline)
                     .foregroundColor(.gray)
                 HStack(spacing: 12) {
-                    TextField("n", value: $viewModel.consumptionDays, formatter: NumberFormatter())
+                    TextField("n", value: $viewModel.consumptionDays, formatter: numberFormatter)
                         .keyboardType(.numberPad)
                         .padding()
                         .background(Color(.systemGray6))
@@ -50,8 +57,8 @@ struct StockCreateView: View {
                     Text("일에")
                     Spacer()
                     HStack(spacing: 0) {
-                        TextField("수량", value: $viewModel.consumptionAmount, formatter: NumberFormatter())
-                            .keyboardType(.decimalPad)
+                        TextField("수량", value: $viewModel.consumptionAmount, formatter: numberFormatter)
+                            .keyboardType(.numberPad)
                             .padding(.leading)
                             .background(Color.clear)
                         
@@ -88,7 +95,7 @@ struct StockCreateView: View {
                     .font(.caption)
                     .foregroundColor(.gray)
                 HStack {
-                    TextField("수량", value: $viewModel.currentAmount, formatter: NumberFormatter())
+                    TextField("수량", value: $viewModel.currentAmount, formatter: numberFormatter)
                         .keyboardType(.numberPad)
                         .padding()
                         .frame(maxWidth: .infinity)

--- a/DueMate/View/Stocks/StockCreateView.swift
+++ b/DueMate/View/Stocks/StockCreateView.swift
@@ -42,7 +42,7 @@ struct StockCreateView: View {
                     .font(.subheadline)
                     .foregroundColor(.gray)
                 HStack(spacing: 12) {
-                    TextField("n", value: $viewModel.usageDays, formatter: NumberFormatter())
+                    TextField("n", value: $viewModel.consumptionDays, formatter: NumberFormatter())
                         .keyboardType(.numberPad)
                         .padding()
                         .background(Color(.systemGray6))
@@ -50,7 +50,7 @@ struct StockCreateView: View {
                     Text("일에")
                     Spacer()
                     HStack(spacing: 0) {
-                        TextField("수량", value: $viewModel.consumptionDays, formatter: NumberFormatter())
+                        TextField("수량", value: $viewModel.consumptionAmount, formatter: NumberFormatter())
                             .keyboardType(.decimalPad)
                             .padding(.leading)
                             .background(Color.clear)
@@ -68,6 +68,12 @@ struct StockCreateView: View {
                             .frame(minWidth: 60)
                             
                         }
+                    }
+                    .sheet(isPresented: $showUnitPicker) {
+                        StockUnitPickerView(
+                            amount: $viewModel.consumptionAmount,
+                            unit: $viewModel.consumptionUnit
+                        )
                     }
                     .padding()
                     .background(Color(.systemGray6))
@@ -152,6 +158,7 @@ struct StockCreateView: View {
             }
             
         }
+        
         .padding(25)
         .onChange(of: viewModel.currentAmount) {
             withAnimation(.easeInOut(duration: 0.3)) {

--- a/DueMate/View/Stocks/StockCreateView.swift
+++ b/DueMate/View/Stocks/StockCreateView.swift
@@ -50,7 +50,7 @@ struct StockCreateView: View {
                     Text("일에")
                     Spacer()
                     HStack(spacing: 0) {
-                        TextField("수량", value: $viewModel.usageAmount, formatter: NumberFormatter())
+                        TextField("수량", value: $viewModel.consumptionDays, formatter: NumberFormatter())
                             .keyboardType(.decimalPad)
                             .padding(.leading)
                             .background(Color.clear)
@@ -59,7 +59,7 @@ struct StockCreateView: View {
                             showUnitPicker = true
                         } label: {
                             HStack {
-                                Text(viewModel.usageUnit)
+                                Text(viewModel.consumptionUnit)
                                 Image(systemName: "chevron.down")
                                     .foregroundStyle(.secondary)
                                     .font(.caption)
@@ -89,7 +89,7 @@ struct StockCreateView: View {
                         .background(Color(.systemGray6))
                         .cornerRadius(15)
                     
-                    Text(viewModel.usageUnit)
+                    Text(viewModel.consumptionUnit)
                         .foregroundColor(.gray)
                 }
                 Group {

--- a/DueMate/View/Stocks/StockCreateView.swift
+++ b/DueMate/View/Stocks/StockCreateView.swift
@@ -132,7 +132,7 @@ struct StockCreateView: View {
                     .cornerRadius(12)
                 }
                 .sheet(isPresented: $showReminderPicker) {
-                    AlertSheet(alert: $viewModel.selectedReminder)
+                    ReminderPickerView(alert: $viewModel.selectedReminder)
                 }
             }
             Spacer()

--- a/DueMate/View/Stocks/StockCreateView.swift
+++ b/DueMate/View/Stocks/StockCreateView.swift
@@ -1,0 +1,169 @@
+//
+//  StockCreateView.swift
+//  DueMate
+//
+//  Created by Kacey Kim on 5/20/25.
+//
+
+import SwiftUI
+
+struct StockCreateView: View {
+    var onComplete: (() -> Void)? = nil
+    @Namespace private var animation
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel = StockCreateViewModel()
+    
+    @State private var showUnitPicker = false
+    @State private var showReminderPicker = false
+    @State private var showExpectedText = false
+    
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Text("새 재고")
+                .font(.system(size: 28, weight: .bold))
+                .frame(maxWidth: .infinity, alignment: .center)
+            
+            // Title
+            VStack(alignment: .leading, spacing: 8) {
+                Text("물건 이름")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                
+                TextField("ex. 휴지", text: $viewModel.title)
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(15)
+            }
+            
+            // Consumption rate
+            VStack(alignment: .leading) {
+                Text("소모 주기")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                HStack(spacing: 12) {
+                    TextField("n", value: $viewModel.usageDays, formatter: NumberFormatter())
+                        .keyboardType(.numberPad)
+                        .padding()
+                        .background(Color(.systemGray6))
+                        .cornerRadius(15)
+                    Spacer()
+                    Text("일에")
+                    Spacer()
+                    HStack(spacing: 0) {
+                        TextField("수량", value: $viewModel.usageAmount, formatter: NumberFormatter())
+                            .keyboardType(.decimalPad)
+                            .padding(.leading)
+                            .frame(width: 80)
+                            .background(Color.clear)
+                        
+                        Button {
+                            showUnitPicker = true
+                        } label: {
+                            HStack(spacing: 4) {
+                                Text(viewModel.usageUnit)
+                                Image(systemName: "chevron.down")
+                            }
+                            .foregroundColor(.primary)
+                            .padding(.horizontal)
+                        }
+                    }
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(15)
+                }
+            }
+            
+            
+            // Current Amount
+            VStack(alignment: .leading, spacing: 6) {
+                Text("현재 재고")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                HStack {
+                    TextField("수량", value: $viewModel.currentAmount, formatter: NumberFormatter())
+                        .keyboardType(.numberPad)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(15)
+                    
+                    Text(viewModel.usageUnit)
+                        .foregroundColor(.gray)
+                }
+                Group {
+                    if showExpectedText {
+                        Text("현재 약 \(viewModel.expectedDaysLeft)일치가 남았어요!")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                        
+                    }
+                }.animation(.easeInOut(duration: 0.3), value: viewModel.currentAmount)
+                
+            }
+            
+            
+            // Reminder Picker
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Reminder")
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                
+                Button(action: {
+                    showReminderPicker = true
+                }) {
+                    HStack {
+                        Text(viewModel.selectedReminder.rawValue)
+                            .foregroundColor(viewModel.selectedReminder == .none ? .gray : .primary)
+                        Spacer()
+                        Image(systemName: "chevron.down")
+                            .foregroundColor(.gray)
+                    }
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(12)
+                }
+                .sheet(isPresented: $showReminderPicker) {
+                    AlertSheet(alert: $viewModel.selectedReminder)
+                }
+            }
+            Spacer()
+            // Submit Button
+            Button {
+                viewModel.createStock()
+            } label: {
+                Text("저장")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(viewModel.isFormValid ? Color.black : Color.gray.opacity(0.4))
+                    .foregroundColor(viewModel.isFormValid ? .white : .gray)
+                    .cornerRadius(16)
+            }
+            .disabled(!viewModel.isFormValid)
+            .padding(.top, 12)
+            .onChange(of: viewModel.isStockCreated) {
+                if viewModel.isStockCreated {
+                    onComplete?()
+                    dismiss()
+                }
+            }
+            
+        }
+        .padding(25)
+        .onChange(of: viewModel.currentAmount) {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                showExpectedText = (viewModel.currentAmount ?? 0) > 0
+            }
+        }
+    }
+    
+    
+    
+}
+
+
+#Preview {
+    StockCreateView()
+}

--- a/DueMate/View/Stocks/StockCreateView.swift
+++ b/DueMate/View/Stocks/StockCreateView.swift
@@ -47,25 +47,26 @@ struct StockCreateView: View {
                         .padding()
                         .background(Color(.systemGray6))
                         .cornerRadius(15)
-                    Spacer()
                     Text("일에")
                     Spacer()
                     HStack(spacing: 0) {
                         TextField("수량", value: $viewModel.usageAmount, formatter: NumberFormatter())
                             .keyboardType(.decimalPad)
                             .padding(.leading)
-                            .frame(width: 80)
                             .background(Color.clear)
                         
                         Button {
                             showUnitPicker = true
                         } label: {
-                            HStack(spacing: 4) {
+                            HStack {
                                 Text(viewModel.usageUnit)
                                 Image(systemName: "chevron.down")
+                                    .foregroundStyle(.secondary)
+                                    .font(.caption)
                             }
                             .foregroundColor(.primary)
-                            .padding(.horizontal)
+                            .frame(minWidth: 60)
+                            
                         }
                     }
                     .padding()

--- a/DueMate/View/Stocks/StockUnitPickerView.swift
+++ b/DueMate/View/Stocks/StockUnitPickerView.swift
@@ -1,0 +1,62 @@
+//
+//  StockUnitPickerView.swift
+//  DueMate
+//
+//  Created by Kacey Kim on 5/26/25.
+//
+
+import SwiftUI
+
+struct StockUnitPickerView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var amount: Int
+    @Binding var unit: String
+    
+    
+    let unitOptions = ["개", "ml", "L", "kg", "g", "장", "롤", "팩", "병", "캔"]
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            HStack{
+                Spacer()
+                Button(action:{
+                    self.dismiss()
+                }){
+                    Image(systemName: "xmark")
+                        .font(.system(size: 20,weight: .bold))
+                        .foregroundColor(.black)
+                }
+            }
+
+            HStack {
+                // consumption amount
+                TextField("수량", value: $amount, formatter: NumberFormatter())
+                    .keyboardType(.numberPad)
+                    .frame(width: .infinity)
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(12)
+                
+                // consumption unit
+                Picker("단위 선택", selection: $unit) {
+                    ForEach(unitOptions, id: \.self) { option in
+                        Text(option).tag(option)
+                    }
+                }
+                .pickerStyle(WheelPickerStyle())
+                .frame(width:.infinity)
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+        .padding(30)
+        .background(.ultraThickMaterial)
+        .presentationDetents([.height(300)])
+        .ignoresSafeArea(edges: .bottom)
+    }
+}
+
+#Preview {
+    StockUnitPickerView(amount: .constant(3), unit: .constant("개"))
+}

--- a/DueMate/View/Stocks/StockUnitPickerView.swift
+++ b/DueMate/View/Stocks/StockUnitPickerView.swift
@@ -13,7 +13,7 @@ struct StockUnitPickerView: View {
     @Binding var unit: String
     
     
-    let unitOptions = ["개", "ml", "L", "kg", "g", "장", "롤", "팩", "병", "캔"]
+    let unitOptions = ["개", "롤", "팩", "병", "장", "캔", "ml", "L", "g", "kg" ]
     
     var body: some View {
         VStack(spacing: 24) {

--- a/DueMate/View/Stocks/StockUnitPickerView.swift
+++ b/DueMate/View/Stocks/StockUnitPickerView.swift
@@ -32,7 +32,7 @@ struct StockUnitPickerView: View {
                 // consumption amount
                 TextField("수량", value: $amount, formatter: NumberFormatter())
                     .keyboardType(.numberPad)
-                    .frame(width: .infinity)
+                    .frame(maxWidth: .infinity)
                     .padding()
                     .background(Color(.systemGray6))
                     .cornerRadius(12)
@@ -44,7 +44,7 @@ struct StockUnitPickerView: View {
                     }
                 }
                 .pickerStyle(WheelPickerStyle())
-                .frame(width:.infinity)
+                .frame(maxWidth: .infinity)
             }
             .padding(.horizontal)
 

--- a/DueMate/ViewModel/ChoreCreateViewModel.swift
+++ b/DueMate/ViewModel/ChoreCreateViewModel.swift
@@ -19,6 +19,12 @@ class ChoreCreateViewModel: ObservableObject {
     @Published var showPicker = false
     @Published var isChoreCreated = false
     
+    // Form Validation
+    var isFormValid: Bool {
+        !title.trimmingCharacters(in: .whitespaces).isEmpty &&
+        Int(cycle) != nil && Int(cycle)! > 0 && Int(cycle)! <= 365
+    }
+    
     // - Network
     func createChore() {
         let cycleInt = Int(cycle) ?? 1

--- a/DueMate/ViewModel/ChoreCreateViewModel.swift
+++ b/DueMate/ViewModel/ChoreCreateViewModel.swift
@@ -15,7 +15,7 @@ class ChoreCreateViewModel: ObservableObject {
     @Published var title: String = ""
     @Published var cycle: String = ""
     @Published var startDate: Date = Date()
-    @Published var selectedAlert: alertOptions = .none
+    @Published var selectedAlert: ReminderOptions = .none
     @Published var showPicker = false
     @Published var isChoreCreated = false
     

--- a/DueMate/ViewModel/ChoreDetailViewModel.swift
+++ b/DueMate/ViewModel/ChoreDetailViewModel.swift
@@ -12,11 +12,11 @@ class ChoreDetailViewModel: ObservableObject {
     @Published var historyDates: [String] = []
     @Published var title: String = ""
     @Published var cycleDays: String = ""
-    @Published var reminderOption: alertOptions = .none
+    @Published var reminderOption: ReminderOptions = .none
     
     @Published var firstTitle: String = ""
     @Published var firstCycleDays: String = ""
-    @Published var firstReminderOption: alertOptions = .none
+    @Published var firstReminderOption: ReminderOptions = .none
     
     
     func fetchHistory(for id: Int){
@@ -25,7 +25,7 @@ class ChoreDetailViewModel: ObservableObject {
         
     }
     
-    func firstInputSetting(title: String, cycleDays: String, reminderOption: alertOptions) {
+    func firstInputSetting(title: String, cycleDays: String, reminderOption: ReminderOptions) {
         self.title = title
         self.cycleDays = cycleDays
         self.reminderOption = reminderOption

--- a/DueMate/ViewModel/StockCreateViewModel.swift
+++ b/DueMate/ViewModel/StockCreateViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  StockCreateViewModel.swift
+//  DueMate
+//
+//  Created by Kacey Kim on 5/21/25.
+//
+
+import Foundation
+import SwiftUI
+
+class StockCreateViewModel: ObservableObject {
+    @Published var title: String = ""
+    @Published var usageDays: Int = 3
+    @Published var usageAmount: Int = 1
+    @Published var usageUnit: String = "개"
+    @Published var currentAmount: Int? = nil
+    @Published var selectedReminder: alertOptions = .none
+    @Published var isStockCreated = false
+    
+    let unitOptions = ["개", "ml", "L", "kg", "g", "장", "롤", "팩"]
+    
+    var isFormValid: Bool {
+        return true
+    }
+    
+    var expectedDaysLeft: Int {
+        guard let currentAmount = currentAmount , usageAmount > 0 else { return 0 }
+        return (currentAmount * usageDays) / usageAmount
+    }
+    
+    
+    func createStock() {
+        print("Stock \(title) created! ")
+    }
+}

--- a/DueMate/ViewModel/StockCreateViewModel.swift
+++ b/DueMate/ViewModel/StockCreateViewModel.swift
@@ -14,7 +14,7 @@ class StockCreateViewModel: ObservableObject {
     @Published var consumptionAmount: Int = 1
     @Published var consumptionUnit: String = "개"
     @Published var currentAmount: Int? = nil
-    @Published var selectedReminder: alertOptions = .none
+    @Published var selectedReminder: ReminderOptions = .none
     @Published var isStockCreated = false
     
     let unitOptions = ["개", "ml", "L", "kg", "g", "장", "롤", "팩", "병", "캔"]

--- a/DueMate/ViewModel/StockCreateViewModel.swift
+++ b/DueMate/ViewModel/StockCreateViewModel.swift
@@ -11,8 +11,8 @@ import SwiftUI
 class StockCreateViewModel: ObservableObject {
     @Published var title: String = ""
     @Published var usageDays: Int = 3
-    @Published var usageAmount: Int = 1
-    @Published var usageUnit: String = "개"
+    @Published var consumptionDays: Int = 1
+    @Published var consumptionUnit: String = "개"
     @Published var currentAmount: Int? = nil
     @Published var selectedReminder: alertOptions = .none
     @Published var isStockCreated = false
@@ -24,8 +24,8 @@ class StockCreateViewModel: ObservableObject {
     }
     
     var expectedDaysLeft: Int {
-        guard let currentAmount = currentAmount , usageAmount > 0 else { return 0 }
-        return (currentAmount * usageDays) / usageAmount
+        guard let currentAmount = currentAmount , consumptionDays > 0 else { return 0 }
+        return (currentAmount * usageDays) / consumptionDays
     }
     
     

--- a/DueMate/ViewModel/StockCreateViewModel.swift
+++ b/DueMate/ViewModel/StockCreateViewModel.swift
@@ -10,22 +10,22 @@ import SwiftUI
 
 class StockCreateViewModel: ObservableObject {
     @Published var title: String = ""
-    @Published var usageDays: Int = 3
-    @Published var consumptionDays: Int = 1
+    @Published var consumptionDays: Int = 3
+    @Published var consumptionAmount: Int = 1
     @Published var consumptionUnit: String = "개"
     @Published var currentAmount: Int? = nil
     @Published var selectedReminder: alertOptions = .none
     @Published var isStockCreated = false
     
-    let unitOptions = ["개", "ml", "L", "kg", "g", "장", "롤", "팩"]
+    let unitOptions = ["개", "ml", "L", "kg", "g", "장", "롤", "팩", "병", "캔"]
     
     var isFormValid: Bool {
         return true
     }
     
     var expectedDaysLeft: Int {
-        guard let currentAmount = currentAmount , consumptionDays > 0 else { return 0 }
-        return (currentAmount * usageDays) / consumptionDays
+        guard let currentAmount = currentAmount , consumptionAmount > 0 else { return 0 }
+        return (currentAmount * consumptionDays) / consumptionAmount
     }
     
     

--- a/DueMate/ViewModel/StockCreateViewModel.swift
+++ b/DueMate/ViewModel/StockCreateViewModel.swift
@@ -20,7 +20,10 @@ class StockCreateViewModel: ObservableObject {
     let unitOptions = ["개", "ml", "L", "kg", "g", "장", "롤", "팩", "병", "캔"]
     
     var isFormValid: Bool {
-        return true
+        !title.trimmingCharacters(in: .whitespaces).isEmpty &&
+        currentAmount != nil && currentAmount! > 0 &&
+        consumptionDays > 0 &&
+        consumptionAmount > 0
     }
     
     var expectedDaysLeft: Int {


### PR DESCRIPTION
## 🔍 Overview
<!-- Explain the purpose of this PR in a way that even developers from different domains can understand. -->

 Added a new view that allowas users to create a stock item they want to track.

## ✨ Changes
<!-- List the main changes made in this PR -->

- When a user sets the unit type, the current stock unit updates accordingly.
- When a user inputs the current amount of the stock, this view displays an estimated days remaining based on the defined consumption rate
- The Save button is enabled only when all required fields (title, consumption days, consumption amount, consumption unit, current amount) are filled in.

## 📸 Screenshots
<!-- If this PR affects the UI, attach screenshots or screen recordings -->

| Initial Screen | Consumption Unit Picker | Input Current Amount |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/142376b6-04e5-4b70-a326-2316198aeb9c" width="220"/> | <img src="https://github.com/user-attachments/assets/abbb10a4-8a85-41e1-a62a-22a03f732813" width="220"/> |  <img src="https://github.com/user-attachments/assets/58e0df76-f4f9-4c22-b1a3-d0065c784bc0" width="220"/> |

## 🔗 Related Task
<!-- Link to relevant Jira ticket(s) -->

- JIRA: [HOME-67](https://home-protectors.atlassian.net/browse/HOME-67)
